### PR TITLE
Fixed the bug in character table, which showed incorrect mass

### DIFF
--- a/src/components/CharacterDetails.vue
+++ b/src/components/CharacterDetails.vue
@@ -19,7 +19,7 @@ defineProps({
       </tr>
       <tr>
         <th>Mass</th>
-        <td>100 kg</td>
+        <td>{{ character.mass }} kg</td>
       </tr>
       <tr>
         <th>Birth year</th>


### PR DESCRIPTION
The bug was fixed, where the characters, when clicked on them and landing on the seperate page for that specific character, would show incorrect mass.