### PR TITLE
Add dynamic homeworld name with link in CharacterDetails

### DIFF
--- a/src/components/CharacterDetails.vue
+++ b/src/components/CharacterDetails.vue
@@ -1,9 +1,40 @@
 <script setup>
-defineProps({
+import { ref, onMounted } from "vue";
+import axios from "@/plugins/axios";
+
+const props = defineProps({
   character: {
     type: Object,
     required: true,
   },
+});
+
+const loading = ref(false);
+const planet = ref({});
+const planetId = extractId(props.character.homeworld);
+
+function extractId(url) {
+  if (!url) return null;
+  const idParts = url.split("/").filter(Boolean);
+  return idParts[idParts.length - 1];
+}
+
+function loadPlanet(id) {
+  loading.value = true;
+  axios
+    .get(`planets/${id}`)
+    .then((response) => {
+      planet.value = response?.data || {};
+    })
+    .finally(() => {
+      loading.value = false;
+    });
+}
+
+onMounted(() => {
+  if (planetId) {
+    loadPlanet(planetId);
+  }
 });
 </script>
 <template>
@@ -28,6 +59,17 @@ defineProps({
       <tr>
         <th>Gender</th>
         <td>{{ character.gender }}</td>
+      </tr>
+      <tr>
+        <th>Homeworld:</th>
+        <td>
+          <RouterLink
+            :to="`/planets/${planetId}`"
+            class="text-blue-600 underline"
+          >
+            {{ planet.name }}
+          </RouterLink>
+        </td>
       </tr>
       <tr>
         <th>Eye color</th>


### PR DESCRIPTION
- Extracted planet ID from the character's homeworld URL
- Fetched planet data using Axios
- Displayed the planet name instead of raw URL
- Made the planet name a clickable link to its detail page